### PR TITLE
use stream cipher for transaction encryption

### DIFF
--- a/go-ethereum-1.10.23/core/state_processor.go
+++ b/go-ethereum-1.10.23/core/state_processor.go
@@ -35,6 +35,7 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
+	"github.com/ethereum/go-ethereum/f3b"
 )
 
 // StateProcessor is a basic Processor, which takes care of transitioning
@@ -245,7 +246,7 @@ func decryptMsgData(hashWithEncSymKey []byte, encMsgData []byte) ([]byte, []byte
 
 	// plaintextMsgData, ShareWithProof := SplitPlaintextWithShares(decrypted_data)
 	plaintextKey, ShareWithProof := SplitPlaintextWithShares(decrypted_data)
-	plaintextMsgData := crypto.DecryptAES(plaintextKey, encMsgData)
+	plaintextMsgData := f3b.DecryptCompact(plaintextKey, encMsgData)
 	log.Info(fmt.Sprintf("length of shares&proof: %v", len(ShareWithProof)))
 	// csvFile, feer := os.Create("shares_size.csv")
 	// if feer != nil {

--- a/go-ethereum-1.10.23/core/types/transaction.go
+++ b/go-ethereum-1.10.23/core/types/transaction.go
@@ -54,7 +54,7 @@ const (
 
 // ################ For encrypted transaction #######################
 const EncryptedBlockDelay uint64 = 2
-const SymKeyLen = 24
+const SymKeyLen = 29
 
 const GBar string = "1d0194fdc2fa2ffcc041d3ff12045b73c86e4ff95ff662a5eee82abdf44a53c7"
 const NodePath string = "D:/EPFL/master_thesis/dela/dkg/pedersen/dkgcli/tmp/node1/"

--- a/go-ethereum-1.10.23/f3b/mod.go
+++ b/go-ethereum-1.10.23/f3b/mod.go
@@ -1,0 +1,47 @@
+// Copyright EPFL DEDIS
+
+package f3b
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/sha512"
+
+	"golang.org/x/crypto/hkdf"
+)
+
+// EncryptCompact encrypts the plaintext using AES-CTR
+// The same secret should NEVER be used to encrypt two different messages.
+//
+// secret can be of any length, and should ideally represent at least 128 bits of entropy.
+//
+// plaintext will have the same length as ciphertext.
+func EncryptCompact(secret []byte, plaintext []byte) (ciphertext []byte) {
+	ciphertext = xorWithKeyStream(secret, plaintext)
+	return
+}
+
+func DecryptCompact(secret []byte, ciphertext []byte) (plaintext []byte) {
+	plaintext = xorWithKeyStream(secret, ciphertext)
+	return
+}
+
+// HKDF personalisation string
+const compactInfo = "DEDIS-F3B-Compact-AES256CTR"
+
+func xorWithKeyStream(secret []byte, input []byte) (output []byte) {
+	var key [32]byte
+	var iv [16]byte
+
+	kdf := hkdf.New(sha512.New, secret, nil, []byte(compactInfo))
+	kdf.Read(key[:])
+	kdf.Read(iv[:])
+	aes256, err := aes.NewCipher(key[:])
+	if err != nil {
+		panic(err)
+	}
+	stream := cipher.NewCTR(aes256, iv[:])
+	output = make([]byte, len(input))
+	stream.XORKeyStream(output, input)
+	return
+}

--- a/go-ethereum-1.10.23/script/f3b-enc/main.go
+++ b/go-ethereum-1.10.23/script/f3b-enc/main.go
@@ -17,8 +17,8 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/keystore"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/f3b"
 )
 
 const authority_file = "../.ethereum/keystore/UTC--2022-09-13T11-34-29.303731400Z--280f6b48e4d9aee0efdb04eebe882023357f6434"
@@ -191,7 +191,7 @@ func sendEtherF3bVerifiedEnc(client *ethclient.Client, nonce uint64, ks *keystor
 
 	// cmd := strings.Join(args[:], " ")
 
-	msg := "Merry Christmas!"
+	msg := "Merry Christmas and a Happy New Year!"
 	fmt.Println("## Plaintext message: ", msg)
 	symKey := make([]byte, types.SymKeyLen)
 	_, err = rand.Read(symKey)
@@ -202,12 +202,12 @@ func sendEtherF3bVerifiedEnc(client *ethclient.Client, nonce uint64, ks *keystor
 	symKeyStr := hex.EncodeToString(symKey)
 	// msgStr := hex.EncodeToString([]byte(msg))
 
-	encryptedMsg := crypto.EncryptAES(symKey, []byte(msg))
+	encryptedMsg := f3b.EncryptCompact(symKey, []byte(msg))
 	// compute hash of cleartext key
 	khash := sha256.Sum256([]byte(symKey))
 	khash[0] = 0
 
-	gBar := "1d0194fdc2fa2ffcc041d3ff12045b73c86e4ff95ff662a5eee82abdf44a53c7"
+	gBar := types.GBar
 
 	args_enc := []string{"dkgcli", "--config", node, "dkg", "verifiableEncrypt", "--GBar", gBar, "--message", symKeyStr}
 


### PR DESCRIPTION
Closes #5

Design choices:
- real world data is not fixed-size.
- Keccak is an XOF so this should work as a stream cipher.
- an AEAD cipher is not necessary since ciphertexts are signed and keys committed to. It would just add overhead.
- keys are by-design single-use, hence IV aren't used. A bit of a footgun but if we added 16 more bytes to the payload people would complain.
- arbitrary secret key length is useful for this project since we have weird lengths: Dela verifiable encryption is limited to 29 bytes, DRand normally produces 32 or 96 bytes, PVSS we don't know yet. (That said if keys are going to be stored in the blockchain at execution time, we might have to KDF them up to 32 bytes upfront anyways)